### PR TITLE
Basic throttle for account creation

### DIFF
--- a/config.js
+++ b/config.js
@@ -31,7 +31,10 @@ var config = {
 
     // 2Captcha API key
     useAutoCatcha: false,
-    captchaApiKey: "YOUR_2CAPTCHA_API_KEY_HERE"
+    captchaApiKey: "YOUR_2CAPTCHA_API_KEY_HERE",
+
+    // account creation delay (maximum 1 account creation per <value> in seconds)
+    throttle: 300
 };
 
 module.exports = config;

--- a/index.js
+++ b/index.js
@@ -344,7 +344,7 @@ function fillSignupPage(ctr) {
                                             if (ctr < end) {
                                                 return function() {
                                                     // Niantic implemented a "no more than 5 accounts per Xmins per IP" throttle.
-                                                    // as a result, we make sure we have at least 2 mins and 1 sec between accounts
+                                                    // as a result, we make sure we have spend some time between accounts
                                                     createAccountEnd = new Date();
                                                     var waitPeriod = throttleMiliseconds - (createAccountEnd.getTime() - createAccountBegin.getTime());
                                                     console.log("Account took " + (createAccountEnd.getTime() - createAccountBegin.getTime()) / 1000 + "s to generate, waiting " + waitPeriod / 1000 + " before starting the next one...");


### PR DESCRIPTION
Default configuration set to 1 account per 5mins which seems to work well for me.  2mins was too fast and resulted in a lot of failures still.