### PR TITLE
fix for issue 104 - puts the currently used nickname back at the fron…

### DIFF
--- a/index.js
+++ b/index.js
@@ -229,6 +229,12 @@ function handleSignupPage(ctr) {
             if (!validated) {
                 // Missing form data, loop over itself
                 console.log("[" + ctr + "] Servers are acting up... Trying again.");
+
+                // put the current nickname back at the front of the list otherwise we will skip it
+                if (useNicknamesFile) {
+                    nicknames.unshift(_nick);
+                }
+
                 return function() {
                     nightmare.wait(500).refresh().wait();
                     handleFirstPage(ctr);


### PR DESCRIPTION
…t of the list (unshift) in the event of a failure during the DOB page.  This prevents nicknames from getting skipped. #104 